### PR TITLE
Fix opus error

### DIFF
--- a/src/bot/discordSR.ts
+++ b/src/bot/discordSR.ts
@@ -90,6 +90,10 @@ export default class DiscordSR {
       });
       const bufferData: Uint8Array[] = [];
 
+      audioStream.on("error", (error) => {
+        this.client.emit("audioStreamError", error);
+      });
+
       audioStream.on("data", (data) => {
         bufferData.push(data);
       });

--- a/src/events.ts
+++ b/src/events.ts
@@ -23,3 +23,11 @@ export declare function voiceJoin(connection: VoiceConnection): void;
  * @event
  */
 export declare function speech(voiceMessage: VoiceMessage): void;
+
+/**
+ * Emitted when error occurs during processing audio stream. Usually when someone tries to talk using web version of discord. See https://github.com/discordjs/opus/issues/49
+ * @asMemberOf DiscordSR
+ * @param error
+ * @event
+ */
+export declare function audioStreamError(error: Error): void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,17 @@
 export {
   default as DiscordSR,
+  DiscordSROptions,
   SpeechRecognition as speechRecognition,
   SpeechRecognitionOptions,
-  DiscordSROptions,
 } from "./bot/discordSR";
-export { speech, voiceJoin } from "./events";
 export { default as VoiceMessage } from "./bot/voiceMessage";
+export { audioStreamError, speech, voiceJoin } from "./events";
 export {
-  resolveSpeechWithGoogleSpeechV2,
   GoogleSpeechV2Options,
+  resolveSpeechWithGoogleSpeechV2,
 } from "./speechRecognition/googleV2";
 export {
   resolveSpeechWithWITAI,
   WitaiOptions as WITAIOptions,
 } from "./speechRecognition/witAI";
-export { wavUrlToBuffer, getDurationFromMonoBuffer } from "./utils/audio";
+export { getDurationFromMonoBuffer, wavUrlToBuffer } from "./utils/audio";


### PR DESCRIPTION
When error occurs during processing audio stream, now it emits an event, which can be handle accordingly.